### PR TITLE
Various fixes

### DIFF
--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -242,8 +242,14 @@ Blockchain.prototype.queueCall = function(tx_params, callback) {
 };
 
 Blockchain.prototype.queueAction = function(method, tx_params, callback) {
-  if (tx_params.from == null)
-    tx_params.from = this.coinbase;
+  if (tx_params.from == null) {
+    if (method === 'eth_call')
+      tx_params.from = this.coinbase;
+    else {
+      callback(new Error("from not found; is required"));
+      return;
+    }
+  }
 
   tx_params.from = this.toHex(tx_params.from);
 

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -242,10 +242,8 @@ Blockchain.prototype.queueCall = function(tx_params, callback) {
 };
 
 Blockchain.prototype.queueAction = function(method, tx_params, callback) {
-  if (tx_params.from == null) {
-    callback(new Error("from not found; is required"));
-    return;
-  }
+  if (tx_params.from == null)
+    tx_params.from = this.coinbase;
 
   tx_params.from = this.toHex(tx_params.from);
 

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -82,22 +82,26 @@ Blockchain.prototype.accountAddresses = function() {
 
 Blockchain.prototype.createBlock = function() {
   var block = new Block();
+  var parent = this.blocks.length != 0 ? this.blocks[this.blocks.length - 1] : null;
+
   block.header.gasLimit = '0x2fefd8';
+
+  // Ensure we have the right block number for the VM.
+  block.header.number = this.toHex(this.blockNumber + 1);
+
+  // Set the timestamp before processing txs
+  block.header.timestamp = this.toHex(new Date().getTime() / 1000 | 0);
+
+  if (parent != null) {
+    block.header.parentHash = this.toHex(parent.hash());
+  }
+
   return block;
 }
 
 Blockchain.prototype.mine = function() {
   this.blockNumber += 1;
   var block = this.pendingBlock;
-  var parent = this.blocks.length != 0 ? this.blocks[this.blocks.length - 1] : null;
-
-  // Update the header for when the block was mined.
-  block.header.timestamp = this.toHex(new Date().getTime());
-  block.header.number = this.toHex(this.blockNumber);
-
-  if (parent != null) {
-    block.header.parentHash = this.toHex(parent.hash());
-  }
 
   this.blocks.push(block);
 
@@ -344,9 +348,6 @@ Blockchain.prototype.processTransaction = function(from, rawTx, callback) {
 
     // Add the transaction to the block.
     block.transactions.push(tx);
-
-    // Ensure we have the right block number for the VM.
-    block.header.number = self.blockNumber + 1;
 
     self.vm.runBlock({
       block: block,

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -90,13 +90,17 @@ Blockchain.prototype.createBlock = function() {
   block.header.number = this.toHex(this.blockNumber + 1);
 
   // Set the timestamp before processing txs
-  block.header.timestamp = this.toHex(new Date().getTime() / 1000 | 0);
+  block.header.timestamp = this.toHex(this.currentTime());
 
   if (parent != null) {
     block.header.parentHash = this.toHex(parent.hash());
   }
 
   return block;
+}
+
+Blockchain.prototype.currentTime = function() {
+  return new Date().getTime() / 1000 | 0;
 }
 
 Blockchain.prototype.mine = function() {
@@ -322,6 +326,9 @@ Blockchain.prototype.processNextAction = function(override) {
     }
   };
 
+  // Update the latest unmined block's timestamp before calls or txs
+  this.updateCurrentTime();
+
   if (queued.method == "eth_sendTransaction") {
     this.processTransaction(queued.from, queued.rawTx, intermediary);
   } else {
@@ -480,5 +487,10 @@ Blockchain.prototype.processCall = function(from, rawTx, callback) {
     });
   });
 };
+
+Blockchain.prototype.updateCurrentTime = function() {
+  var block = this.latestBlock();
+  block.header.timestamp = this.toHex(this.currentTime());
+}
 
 module.exports = Blockchain;

--- a/lib/server.js
+++ b/lib/server.js
@@ -81,6 +81,8 @@ Server = {
       functions[method] = createHandler(method);
     });
 
+    // TODO: the reviver option is a hack to allow batches to work with jayson
+    // it become unecessary after the fix of this bug https://github.com/ethereum/web3.js/issues/345
     var server = jayson.server(functions, {
       reviver: function(key, val) {
         if (typeof val === 'object' && val.hasOwnProperty('method') &&

--- a/lib/server.js
+++ b/lib/server.js
@@ -81,7 +81,15 @@ Server = {
       functions[method] = createHandler(method);
     });
 
-    var server = jayson.server(functions);
+    var server = jayson.server(functions, {
+      reviver: function(key, val) {
+        if (typeof val === 'object' && val.hasOwnProperty('method') &&
+            val.method === 'eth_call' && val.hasOwnProperty('params') &&
+            val.params.constructor === Array && val.params.length === 1)
+          val.params.push('latest');
+        return val;
+      }
+    });
     var http = server.http();
     http.listen(servicePort);
 


### PR DESCRIPTION
Fixes to Ethersim:
- `block.timestamp` in seconds vs milliseconds
- set block headers in `createBlock()`, otherwise `block.timestamp` isn't available to ethereumjs-vm
- set `tx_params.from` to `this.coinbase` if null
- inject defaultBlock `latest` into eth_call params if it's not already there. This was missing during batched eth_calls. Now batches work as expected
